### PR TITLE
Benchmark with variance

### DIFF
--- a/benchmark_dolt.sh
+++ b/benchmark_dolt.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+set -eo pipefail
+
+DOLT_ROOT=/Users/max-hoffman/go/src/github.com/dolthub/dolt
+SCRIPTS_ROOT=/Users/max-hoffman/go/src/github.com/dolthub/dolt/go/performance/scripts/sysbench-lua-scripts
+ROOT_USER=user
+ROOT_PASS=pass
+ROOT_TABLE_SIZE=10000
+ROOT_TIMEOUT=30
+ROOT_EVENTS=200
+
+benchmark_dolt() {
+    # version, wd, port
+    if [ "$#" -ne 4 ]; then
+        echo "benchmark_dolt expects 5 arguments, found ${$#}"
+        echo "usage: benchmark_dolt [committish] [script logs dir] [server logs dir] [port]"
+        exit 1
+    fi
+    doltv=$1
+    server_log_dir=$2
+    script_log_dir=$3
+    port=$4
+    scripts=('oltp_read_only' 'oltp_point_select')
+    #scripts=('oltp_delete_insert' 'groupby_scan' 'covering_index_scan' 'index_join_scan' 'index_scan' 'table_scan' 'types_delete_insert' 'types_table_scan')
+    #scripts=('oltp_read_only' 'oltp_point_select' 'select_random_points' 'select_random_ranges' 'covering_index_scan' 'index_scan' 'table_scan' 'groupby_scan' 'index_join_scan')
+    #writeTests=('oltp_read_write', 'oltp_update_index', 'oltp_update_non_index', 'oltp_insert', 'bulk_insert', 'oltp_write_only', 'oltp_delete_insert')
+
+    dolt_bin="$server_log_dir/dolt_$doltv"
+    install_dolt_version $doltv $dolt_bin
+
+    server_log="$server_log_dir/$doltv.log"
+    cd $wd
+    dolt init
+    dolt sql -q "create database sbtest"
+    start_server $dolt_bin $wd $port $server_log
+
+    #SERVER_PID="$!"
+
+    END=${#scripts[@]}
+    for ((i=0;i<=END-1;i++)); do
+        script_name=${scripts[$i]}
+        script_log="$script_log_dir/$script_name.log"
+        echo "script: $script_name"
+        run_script $script_name $script_log $port
+    done
+
+    #kill_server $SERVER_PID
+}
+
+install_dolt_version() {
+    if [ "$#" -ne 2 ]; then
+        echo "install_dolt_version expects 2 arguments, found ${$#}"
+        echo "usage: install_dolt_version [committish] [dolt_bin]"
+        exit 1
+    fi
+    doltv=$1
+    dolt_bin=$2
+    cd $DOLT_ROOT/go
+    git checkout $doltv
+    go build -o $dolt_bin $DOLT_ROOT/go/cmd/dolt
+}
+
+start_server() {
+    if [ "$#" -ne 4 ]; then
+        echo "start_server expects 3 arguments, found $#"
+        echo "usage: start_server [dolt_bin] [data dir] [port] [server log]"
+        exit 1
+    fi
+    dolt_bin=$1
+    wd=$2
+    port=$3
+    server_log=$4
+
+    $dolt_bin sql-server -l trace --user=$ROOT_USER --password=$ROOT_PASS --port "$port" &>"$server_log" &
+    sleep 1
+}
+
+kill_server() {
+    pid=$1
+    kill -15 $pid
+}
+
+run_script() {
+    if [ "$#" -ne 3 ]; then
+        echo "run_script expects 3 arguments, found ${$#}"
+        echo "usage: run_script [name] [log file] [port]"
+        exit 1
+    fi
+    script_name=$1
+    script_log=$2
+    port=$3
+
+    default_opts="
+      --db-driver="mysql" \
+      --mysql-host="0.0.0.0" \
+      --mysql-port="$port" \
+      --mysql-user="$ROOT_USER" \
+      --mysql-password="$ROOT_PASS" \
+      --mysql-port="$port" \
+      --rand-seed=1 \
+      --table-size=$ROOT_TABLE_SIZE \
+      --rand-type=uniform \
+      --events=$ROOT_EVENTS \
+      --time=$ROOT_TIMEOUT \
+      --histogram=on
+    "
+    pwd
+    sysbench $default_opts "$script_name" prepare
+    sysbench $default_opts "$script_name" run > "$script_log"
+    sysbench $default_opts "$script_name" cleanup
+}
+
+format_hist() {
+    if [ "$#" -ne 2 ]; then
+        echo "format_hist expects 2 arguments, found ${$#}"
+        echo "usage: format_hist [log directory] [output directory] [port]"
+        exit 1
+    fi
+    log_dir=$1
+    hist_dir=$2
+
+    for f in $log_dir/*.log; do
+        new_file="$hist_dir/$(basename -s .log $f).csv"
+        # filter for histogram | convert histogram into csv
+        cat $f | sed -n '/Latency histogram/,/SQL statistics/p' | tail -n +2 | tail -r | tail -n +3 | tail -r | awk '{ printf "%s,%s\n", $1, $3 }' > $new_file
+    done
+}
+
+print_stats="
+import os, csv, sys, statistics
+file = sys.argv[1]
+name = os.path.basename(file)[:-4] # remove .csv postfix
+values = []
+for i, row in enumerate(csv.reader(open(file), delimiter=',')):
+    if i == 0: continue
+    for _ in range(int(row[1])):
+        values.append(float(row[0]))
+stdev = statistics.stdev(values)
+mean = statistics.mean(values)
+print(f'{name},{mean},{stdev}')
+"
+
+collect_summary() {
+    if [ "$#" -ne 2 ]; then
+        echo "collect_summary expects 2 arguments, found ${$#}"
+        echo "usage: collect_summary [log directory] [output directory] [port]"
+        exit 1
+    fi
+    hist_logs=$1
+    summary_file=$2
+
+    echo "script,mean,var" > $summary_file
+    for f in $hist_logs/*.csv; do
+        python3 -c "$print_stats" $f >> $summary_file
+    done
+}
+
+run () {
+    # get versions from ENV variables
+    # get scripts from env variables
+
+    versions=('main' 'v0.40.21')
+
+    tmp_dir=`mktemp -d`
+    echo "output dir: $tmp_dir"
+
+    summary_dir="$tmp_dir/summary"
+    mkdir -p $summary_dir
+
+    VERLEN=${#versions[@]}
+    for ((j=0;j<=VERLEN-1;j++)); do
+        dolt_version=${versions[$j]}
+        wd="$tmp_dir/$dolt_version"
+        mkdir -p $wd
+        cp $SCRIPTS_ROOT/*.lua "$wd/"
+        server_logs="$wd/server_logs/"
+        script_logs="$wd/script_logs/"
+        mkdir -p $server_logs $script_logs
+        port=3309
+
+        benchmark_dolt "$dolt_version" "$server_logs" "$script_logs" "$port"
+
+        hist_logs="$wd/hist_logs"
+        mkdir -p $hist_logs
+        format_hist $script_logs $hist_logs
+
+        version_summary="$summary_dir/$dolt_version.csv"
+        collect_summary $hist_logs $version_summary
+        echo "summary for $dolt_version at $version_summary"
+        cat $version_summary
+    done
+    # creating working dir, port, call benchmark
+    # histogram outputs in histograms/{script_name}
+    # consolidate histograms
+    # logs in logs/{script_name}
+    # push results to S3? just email?
+}
+
+VERSIONS=('main')
+scripts="oltp_delete_insert groupby_scan"
+run $versions $scripts


### PR DESCRIPTION
This is a short benchmark-runner that loops over 1) a list of dolt versions (commitish), 2) a list of scripts to run, and outputs test latency mean and variance. I think the variance metrics can be useful to give context on which tests have variability, and to avoid running hour long sysbench scripts. I intentionally undershot the event count to expose which tests are variable for PR testing. Tests that quickly run enough events to get a realistic variance also terminate early. This is also a fast way to get accurate comparisons for all tests on a variety of test versions. I also think a test runner not tied to a specific version of Dolt is valuable. Next steps would be plugging this into a CI trigger, maybe add MySQL after.

Sample read scripts output for `main`, `0.40.21`, and `0.40.20`, each take ~2 minutes to run:
```
summary for main at /var/folders/h_/n5qdj2tj3n741n128t7v2d7h0000gn/T/tmp.5USkhudY/summary/main.csv
| script               | mean          | var                 |
|----------------------|---------------|---------------------|
| covering_index_scan  | 15.10451      | 1.1138508014719468  |
| groupby_scan         | 16.24212      | 1.5890066286613307  |
| index_join_scan      | 17.61924      | 0.6317204651827049  |
| index_scan           | 156.601046875 | 7.391887008220157   |
| oltp_point_select    | 0.38645       | 0.09210223454422917 |
| oltp_read_only       | 8.27044       | 0.6200027446851226  |
| select_random_points | 1.048035      | 0.4325851631666992  |
| select_random_ranges | 1.402725      | 0.2969347412780954  |
| table_scan           | 150.4124      | 7.624369498604871   |


summary for v0.40.21 at /var/folders/h_/n5qdj2tj3n741n128t7v2d7h0000gn/T/tmp.O0fqhYcT/summary/v0.40.21.csv
| script               | mean                | var                 |
|----------------------|---------------------|---------------------|
| covering_index_scan  | 14.246475           | 0.5857827811642662  |
| groupby_scan         | 15.6504             | 0.9181732957372618  |
| index_join_scan      | 18.87815            | 2.4337875991732405  |
| index_scan           | 162.60002162162164  | 8.893199692533006   |
| oltp_point_select    | 0.41635500000000003 | 0.0904226201021108  |
| oltp_read_only       | 8.550575            | 0.9403220149683675  |
| select_random_points | 0.78283             | 0.19947786391215133 |
| select_random_ranges | 1.321045            | 0.26617484519781426 |
| table_scan           | 157.79160209424083  | 11.554515638977     |


summary for v0.40.20 at /var/folders/h_/n5qdj2tj3n741n128t7v2d7h0000gn/T/tmp.O0fqhYcT/summary/v0.40.20.csv
| script               | mean               | var                 |
|----------------------|--------------------|---------------------|
| covering_index_scan  | 15.91268           | 1.5481837527442621  |
| groupby_scan         | 18.21874           | 2.5152333183281708  |
| index_join_scan      | 19.023905          | 2.7848944885825904  |
| index_scan           | 164.4929617486339  | 38.78926194056976   |
| oltp_point_select    | 0.38974            | 0.10950419280194722 |
| oltp_read_only       | 8.752              | 1.3798065919380798  |
| select_random_points | 0.839795           | 0.23001831470668266 |
| select_random_ranges | 1.57079            | 0.4907979820618458  |
| table_scan           | 156.92905729166665 | 10.185672335364126  |
